### PR TITLE
allow error-messages prop to be String or Array

### DIFF
--- a/src/components/DatetimePicker.vue
+++ b/src/components/DatetimePicker.vue
@@ -153,7 +153,7 @@ export default {
       default: false
     },
     errorMessages: {
-      type: String,
+      type: [Array, String],
       default: ''
     },
     min: {


### PR DESCRIPTION
the vuetify API for `error-messages` allows a string or an array

I am using your fork because it solves the `v-text-input` clearing when passing in a null date, but I was getting prop validation messages for error messages.